### PR TITLE
Api fixes

### DIFF
--- a/itu-minitwit/src/MiniTwit.Core/DTOs/Simulator/RegisterRequestDTO.cs
+++ b/itu-minitwit/src/MiniTwit.Core/DTOs/Simulator/RegisterRequestDTO.cs
@@ -5,11 +5,11 @@ namespace Chirp.Core.DTOs.Simulator;
 public class RegisterRequestDTO
 {
     [JsonPropertyName("username")]
-    public string Username { get; set; }
+    public string? Username { get; set; }
 
     [JsonPropertyName("email")]
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
     [JsonPropertyName("pwd")]
-    public string Pwd { get; set; }
+    public string? Pwd { get; set; }
 }

--- a/itu-minitwit/src/MiniTwit.Infrastructure/DbInitializer.cs
+++ b/itu-minitwit/src/MiniTwit.Infrastructure/DbInitializer.cs
@@ -780,4 +780,22 @@ public static class DbInitializer
             await userManager.CreateAsync(a12, "M32Want_Access");
         }
     }
+    
+    public static async Task SeedDatabaseAchievements(ChirpDBContext chirpContext)
+    {
+        if (!chirpContext.Achievements.Any())
+        {
+            Achievement ach1 = new Achievement() { AchievementId = 1, Title = "Rookie Chirper", Description = "Welcome aboard! You signed up successfully to Chirp", ImagePath = "/images/Badges/Signup-badge.png" };
+            Achievement ach2 = new Achievement() { AchievementId = 2, Title = "Novice Cheepster", Description = "Congratulations! You created your first Cheep.", ImagePath = "/images/Badges/First-cheep-badge.png" };
+            Achievement ach3 = new Achievement() { AchievementId = 3, Title = "Branching Out", Description = "You followed your first Chirper. Every great tree starts with a single branch.", ImagePath = "/images/Badges/First-following-badge.png" };
+            Achievement ach4 = new Achievement() { AchievementId = 4, Title = "Social Magnet", Description = "Someone followed you. You must be cheeping some good stuff", ImagePath = "/images/Badges/First-follower-badge.png" };
+            
+            chirpContext.Achievements.Add(ach1);
+            chirpContext.Achievements.Add(ach2);
+            chirpContext.Achievements.Add(ach3);
+            chirpContext.Achievements.Add(ach4);
+
+            await chirpContext.SaveChangesAsync();
+        }
+    }
 }

--- a/itu-minitwit/src/MiniTwit.Web/Controllers/SimulatorApiController.cs
+++ b/itu-minitwit/src/MiniTwit.Web/Controllers/SimulatorApiController.cs
@@ -111,7 +111,7 @@ public class SimulatorApiController : ControllerBase
         foreach(var m in messages) {
             dtos.Add(new MessageDTO {
                 Content = m.Message,
-                PubDate = m.Timestamp.ToString(),
+                PubDate = m.Timestamp.ToString("yyyy-MM-dd HH':'mm':'ss"),
                 User = m.AuthorName
             });
         }
@@ -137,7 +137,7 @@ public class SimulatorApiController : ControllerBase
         foreach(var m in messages) {
             dtos.Add(new MessageDTO {
                 Content = m.Message,
-                PubDate = m.Timestamp.ToString(),
+                PubDate = m.Timestamp.ToString("yyyy-MM-dd HH':'mm':'ss"),
                 User = m.AuthorName
             });
         }

--- a/itu-minitwit/src/MiniTwit.Web/Controllers/SimulatorApiController.cs
+++ b/itu-minitwit/src/MiniTwit.Web/Controllers/SimulatorApiController.cs
@@ -130,7 +130,7 @@ public class SimulatorApiController : ControllerBase
             return StatusCode(403, new ErrorResponseDTO { Status = 403, ErrorMsg = "You are not authorized to use this resource!" });
         
         var user = await _authorService.GetAuthorByNameAsync(username);
-        if (user == null) return NotFound();
+        if (user == null) return StatusCode(404, string.Empty);
         
         var (messages, _) = await _cheepService.GetCheepsFromAuthorAmountAsync(no, user.Id);
         
@@ -156,7 +156,7 @@ public class SimulatorApiController : ControllerBase
             return StatusCode(403, new ErrorResponseDTO { Status = 403, ErrorMsg = "You are not authorized to use this resource!" });
         
         var user = await _authorService.GetAuthorByNameAsync(username);
-        if (user == null) return NotFound();
+        if (user == null) return StatusCode(404, string.Empty);
 
         var cheep = new Cheep
         {
@@ -183,7 +183,7 @@ public class SimulatorApiController : ControllerBase
             return StatusCode(403, new ErrorResponseDTO { Status = 403, ErrorMsg = "You are not authorized to use this resource!" });
         
         var user = await _authorService.GetAuthorByNameAsync(username);
-        if (user == null) return NotFound();
+        if (user == null) return StatusCode(404, string.Empty);
         
         var followingNames = await _authorService.GetFollowingAmountAsync(no, user.Id);
         
@@ -199,19 +199,19 @@ public class SimulatorApiController : ControllerBase
             return StatusCode(403, new ErrorResponseDTO { Status = 403, ErrorMsg = "You are not authorized to use this resource!" });
 
         var user = await _authorService.GetAuthorByNameAsync(username);
-        if (user == null) return NotFound();
+        if (user == null) return StatusCode(404, string.Empty);
 
         if (!string.IsNullOrEmpty(payload.Follow))
         {
             var userToFollow = await _authorService.GetAuthorByNameAsync(payload.Follow);
-            if (userToFollow == null) return NotFound();
+            if (userToFollow == null) return StatusCode(404, string.Empty);
             
             await _authorService.FollowAuthorAsync(user.Id, userToFollow.Id);
         }
         else if (!string.IsNullOrEmpty(payload.Unfollow))
         {
             var userToUnfollow = await _authorService.GetAuthorByNameAsync(payload.Unfollow);
-            if (userToUnfollow == null) return NotFound();
+            if (userToUnfollow == null) return StatusCode(404, string.Empty);
             
             await _authorService.UnfollowAuthorAsync(user.Id, userToUnfollow.Id);
         }

--- a/itu-minitwit/src/MiniTwit.Web/Program.cs
+++ b/itu-minitwit/src/MiniTwit.Web/Program.cs
@@ -119,7 +119,9 @@ using (var scope = app.Services.CreateScope())
     using var context = scope.ServiceProvider.GetService<ChirpDBContext>();
     var userManager = scope.ServiceProvider.GetRequiredService<UserManager<Author>>();
     if (context == null) return;
-    if (DbInitializer.CreateDb(context)) await DbInitializer.SeedDatabase(context, userManager);
+    if (DbInitializer.CreateDb(context)) await DbInitializer.SeedDatabaseAchievements(context);
+    // Replace with line above to seed the database with dummy-data
+    // if (DbInitializer.CreateDb(context)) await DbInitializer.SeedDatabase(context, userManager);
 }
 
 //The tests use the instead of a delay to know when the server is ready


### PR DESCRIPTION
Updated the format PubDate in cheeps from xx/xx/xxxx xx.xx.xx to xxxx-xx-xx xx:xx:xx, as stated in the swagger3.

Changed NoResponse() to: StatusCode(404, string.Empty), as this otherwise gives more context.

Removed seeding the database, but this does result in an error responses if achievements are not populated in database.

Added string? several places to handle warnings, and get correct information from intellisense.

Changed structure and checks in /Register, to better match swagger3.