### PR TITLE
Allow spaces in names

### DIFF
--- a/itu-minitwit/src/MiniTwit.Web/Program.cs
+++ b/itu-minitwit/src/MiniTwit.Web/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddDefaultIdentity<Author>(options =>
     options.Password.RequireUppercase = false;
     options.Password.RequiredLength = 1;
     options.Password.RequiredUniqueChars = 0;
+    options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+ ";
 }).AddEntityFrameworkStores<ChirpDBContext>();
 
 builder.Services.AddScoped<IAchievementRepository, AchievementRepository>();


### PR DESCRIPTION
Most names contain spaces, which for some reason, are not valid when sent through an API request. This is now addressed.