### PR TITLE
Session 9 Done - Security Hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ IMAGE_TAG=latest
 POSTGRES_CONNECTION_STRING=Host=db;Database=;Username=;Password=;Port=5432
 GRAFANA_ADMIN_USER=
 GRAFANA_ADMIN_PASSWORD=
+DOMAIN_NAME=minitwit.tech
+LETSENCRYPT_EMAIL=you@example.com

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -55,6 +55,13 @@ jobs:
           docker run --rm -i hadolint/hadolint < itu-minitwit/monitoring/prometheus/Dockerfile
           docker run --rm -i hadolint/hadolint < itu-minitwit/monitoring/grafana/Dockerfile
 
+      - name: Security Static Code Analysis (Semgrep)
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: >-
+            p/security-audit
+            p/csharp
+
       - name: Build project
         working-directory: itu-minitwit
         run: dotnet build --no-restore
@@ -80,6 +87,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # --- LOAD IMAGES LOCALLY FOR SECURITY SCAN ---
+      - name: Build app image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: ./itu-minitwit
+          file: ./itu-minitwit/Dockerfile
+          load: true
+          tags: local-app-image:test
+
+      - name: Trivy Vulnerability Scanner (App Image)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'local-app-image:test'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
       # Builds the app image and tags it with both the unique GitHub run number and :latest
       - name: Build and push app image
         uses: docker/build-push-action@v6
@@ -92,6 +118,24 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
 
       # Build and push Prometheus image
+      - name: Build Prometheus image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: ./itu-minitwit/monitoring/prometheus
+          file: ./itu-minitwit/monitoring/prometheus/Dockerfile
+          load: true
+          tags: local-prometheus-image:test
+
+      - name: Trivy Vulnerability Scanner (Prometheus)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'local-prometheus-image:test'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
       - name: Build and push Prometheus image
         uses: docker/build-push-action@v6
         with:
@@ -102,6 +146,24 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/prometheus_image:latest
 
       # Build and push Grafana image
+      - name: Build Grafana image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: ./itu-minitwit/monitoring/grafana
+          file: ./itu-minitwit/monitoring/grafana/Dockerfile
+          load: true
+          tags: local-grafana-image:test
+
+      - name: Trivy Vulnerability Scanner (Grafana)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'local-grafana-image:test'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
       - name: Build and push Grafana image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -5,9 +5,9 @@
 #    If any test fails, the pipeline halts immediately to protect the production server.
 # 3. Docker Image: If tests pass, it logs into Docker Hub, builds a new image using the GitHub run
 #    number as a tag (e.g., :45), and pushes it to the registry.
-# 4. Deployment: Connects to the DigitalOcean droplet via SSH, pulls the new image, and swaps containers.
-#    It mounts a Managed Docker Volume and passes the DB path as an environment variable so the
-#    simulator's registered users and cheeps survive the deployment.
+# 4. Deployment: Connects to the DigitalOcean droplet via SSH, updates the app container, and starts
+#    the nginx-proxy + ACME companion containers so nginx owns ports 80/443 and Let's Encrypt renewals.
+#    The app stays on the Docker network and the proxy handles TLS termination for minitwit.tech.
 
 name: CI_CD
 
@@ -23,7 +23,6 @@ env:
   IMAGE_NAME: minitwitimage
   CONTAINER_NAME: minitwit
   APP_PORT: "5273"
-  HOST_PORT: "8080"
 
 jobs:
   build_test_and_deploy:
@@ -127,4 +126,4 @@ jobs:
             server ansible_host=${{ secrets.SSH_HOST }} ansible_user=${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           options: |
-            --extra-vars "dockerhub_username=${{ secrets.DOCKERHUB_USERNAME }} image_tag=${{ github.run_number }} postgres_connection_string='${{ secrets.POSTGRES_CONNECTION_STRING }}' grafana_admin_user='${{ secrets.GRAFANA_ADMIN_USER }}' grafana_admin_password='${{ secrets.GRAFANA_ADMIN_PASSWORD }}'"
+            --extra-vars "dockerhub_username=${{ secrets.DOCKERHUB_USERNAME }} image_tag=${{ github.run_number }} postgres_connection_string='${{ secrets.POSTGRES_CONNECTION_STRING }}' grafana_admin_user='${{ secrets.GRAFANA_ADMIN_USER }}' grafana_admin_password='${{ secrets.GRAFANA_ADMIN_PASSWORD }}' domain_name='minitwit.tech' letsencrypt_email='${{ secrets.LETSENCRYPT_EMAIL }}'"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MiniTwit 
 Our links:
-Minitwit Website: http://165.227.170.149
+Minitwit Website: https://minitwit.tech, https://www.minitwit.tech/ or http://165.227.170.149
 Monitoring: http://165.227.170.149:3000
 
 ### 1. Local Setup (Vagrant + Ansible)
@@ -40,6 +40,29 @@ open http://localhost
 docker-compose down
 ```
 > ⚠️ **Note:** This connects directly to the **production database**. Any cheeps or users you create will be real.
+
+### 2b. Docker Compose with TLS Proxy
+This is an optional manual setup. The CI/CD pipeline now deploys the same containerized proxy stack through Ansible, so you do not need a separate production compose file to use the pipeline.
+
+For the production stack, Nginx and Certbot run as Docker containers using the `nginxproxy/nginx-proxy` and `nginxproxy/acme-companion` images.
+
+1. Set `DOMAIN_NAME=minitwit.tech` and `LETSENCRYPT_EMAIL=you@example.com` in `.env`.
+2. If you already installed host-level Nginx or Certbot on the server, stop them first so ports `80` and `443` are free:
+   ```bash
+   sudo systemctl stop nginx
+   sudo systemctl disable nginx
+   ```
+3. Start the production stack:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+   ```
+4. Watch the certificate container logs until issuance completes:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f acme-companion
+   ```
+5. Open `https://minitwit.tech` and confirm the lock icon.
+
+The app container listens on port `5273` internally. The proxy container owns public ports `80` and `443`, and the ACME companion handles renewal automatically.
 
 ### Logging Stack (Loki + Alloy)
 The Docker Compose setup includes a Grafana Loki logging stack with Grafana Alloy:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -7,8 +7,9 @@
     image_name: "minitwitimage"
     container_name: "minitwit"
     app_port: "5273"
-    host_port: "8080"
     db_volume: "minitwit_db_volume"
+    domain_name: "{{ domain_name | default('minitwit.tech', true) }}"
+    letsencrypt_email: "{{ letsencrypt_email | default('bror@live.dk', true) }}"
     # These fall back to 'latest' if run locally via Vagrant
     dockerhub_user: "{{ dockerhub_username | default('sn3ke') }}"
     app_version: "{{ image_tag | default('latest') }}"

--- a/ansible/roles/minitwit/tasks/main.yml
+++ b/ansible/roles/minitwit/tasks/main.yml
@@ -222,6 +222,28 @@
     networks:
       - name: minitwit_network
 
+# --- One-Time Bare-Metal Nginx/Certbot Cleanup ---
+- name: Stop and disable bare-metal Nginx and Certbot services (one-time cleanup)
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop:
+    - nginx
+    - certbot.timer
+    - certbot
+  ignore_errors: true
+
+- name: Remove bare-metal Nginx and Certbot packages (one-time cleanup)
+  ansible.builtin.apt:
+    name:
+      - nginx
+      - nginx-common
+      - certbot
+      - python3-certbot-nginx
+    state: absent
+    purge: true
+
 - name: Pull and Run Nginx Proxy Container
   community.docker.docker_container:
     name: "itu-minitwit-nginx-proxy"
@@ -238,6 +260,8 @@
       - "nginx-vhost:/etc/nginx/vhost.d"
       - "nginx-html:/usr/share/nginx/html"
       - "/var/run/docker.sock:/tmp/docker.sock:ro"
+    networks:
+      - name: minitwit_network
 
 - name: Pull and Run ACME Companion Container
   community.docker.docker_container:
@@ -256,6 +280,8 @@
       - "nginx-html:/usr/share/nginx/html"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "acme:/etc/acme.sh"
+    networks:
+      - name: minitwit_network
 
 - name: Cleanup dangling images
   community.docker.docker_prune:

--- a/ansible/roles/minitwit/tasks/main.yml
+++ b/ansible/roles/minitwit/tasks/main.yml
@@ -58,6 +58,16 @@
     state: present
     driver: bridge
 
+- name: Create Nginx and ACME volumes
+  community.docker.docker_volume:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - nginx-certs
+    - nginx-vhost
+    - nginx-html
+    - acme
+
 - name: Create monitoring config directories
   ansible.builtin.file:
     path: "{{ item }}"
@@ -203,12 +213,49 @@
     restart_policy: always
     recreate: true
     pull: true
-    ports:
-      - "{{ host_port }}:{{ app_port }}"
     env:
       POSTGRES_CONNECTION_STRING: "{{ postgres_connection_string }}"
+      VIRTUAL_HOST: "{{ domain_name }}"
+      VIRTUAL_PORT: "{{ app_port }}"
+      LETSENCRYPT_HOST: "{{ domain_name }}"
+      LETSENCRYPT_EMAIL: "{{ letsencrypt_email }}"
     networks:
       - name: minitwit_network
+
+- name: Pull and Run Nginx Proxy Container
+  community.docker.docker_container:
+    name: "itu-minitwit-nginx-proxy"
+    image: "nginxproxy/nginx-proxy:1.6"
+    state: started
+    restart_policy: always
+    recreate: true
+    pull: true
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "nginx-certs:/etc/nginx/certs:ro"
+      - "nginx-vhost:/etc/nginx/vhost.d"
+      - "nginx-html:/usr/share/nginx/html"
+      - "/var/run/docker.sock:/tmp/docker.sock:ro"
+
+- name: Pull and Run ACME Companion Container
+  community.docker.docker_container:
+    name: "itu-minitwit-acme-companion"
+    image: "nginxproxy/acme-companion:2.5"
+    state: started
+    restart_policy: always
+    recreate: true
+    pull: true
+    env:
+      NGINX_PROXY_CONTAINER: "itu-minitwit-nginx-proxy"
+      DEFAULT_EMAIL: "{{ letsencrypt_email }}"
+    volumes:
+      - "nginx-certs:/etc/nginx/certs"
+      - "nginx-vhost:/etc/nginx/vhost.d"
+      - "nginx-html:/usr/share/nginx/html"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "acme:/etc/acme.sh"
 
 - name: Cleanup dangling images
   community.docker.docker_prune:

--- a/itu-minitwit/Dockerfile
+++ b/itu-minitwit/Dockerfile
@@ -1,23 +1,19 @@
+# Build Stage (stays the same)
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /source
-
-# 1. Copy everything first (simpler for multi-project debugging)
 COPY . .
-
-# 2. Move into the Web project folder
 WORKDIR /source/src/MiniTwit.Web
+RUN dotnet restore && dotnet publish -c Release -o /app
 
-# 3. Restore and Publish in one step
-RUN dotnet restore && \
-    dotnet publish MiniTwit.Web.csproj -c Release -o /app
-
-# Stage 2: Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+# Stage 2: Runtime  
+# "chiseled" images have no shell and a much smaller attack surface
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble-chiseled
 WORKDIR /app
 COPY --from=build /app .
 
-# Ensure the app binds to the right port and interface
+# Run as a non-privileged user (Chiseled images do this by default, but it's good to be explicit)
+USER $APP_UID
+
 ENV ASPNETCORE_URLS=http://+:5273
 EXPOSE 5273
-
 ENTRYPOINT ["dotnet", "MiniTwit.Web.dll"]

--- a/itu-minitwit/src/MiniTwit.Web/Program.cs
+++ b/itu-minitwit/src/MiniTwit.Web/Program.cs
@@ -113,7 +113,7 @@ if (clientId != null && clientSecret != null)
 
 var app = builder.Build();
 
-// Read the proxy headers before any HTTPS-related middleware runs.
+//Nginx proxy intercepts HTTPS traffic, decrypts it and forwards to the .NET container over plain HTTP.
 app.UseForwardedHeaders();
 
 // Configure the HTTP request pipeline.

--- a/itu-minitwit/src/MiniTwit.Web/Program.cs
+++ b/itu-minitwit/src/MiniTwit.Web/Program.cs
@@ -6,6 +6,7 @@ using Chirp.Infrastructure;
 using Chirp.Infrastructure.Chirp.Repositories;
 using Chirp.Infrastructure.Chirp.Services;
 using Chirp.Infrastructure.Data;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Minitwit.Services;
@@ -24,6 +25,14 @@ Log.Logger = new LoggerConfiguration()
     .CreateBootstrapLogger();
 
 var builder = WebApplication.CreateBuilder(args);
+
+// The app runs behind nginx in production, so trust forwarded scheme and client IP headers.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 
 // Replace the default .NET logging with Serilog, configured from appsettings.json
 builder.Host.UseSerilog((context, services, config) =>
@@ -104,15 +113,25 @@ if (clientId != null && clientSecret != null)
 
 var app = builder.Build();
 
+// Read the proxy headers before any HTTPS-related middleware runs.
+app.UseForwardedHeaders();
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-    app.UseHsts();
+
+    if (builder.Configuration.GetValue<bool>("EnableHttpsRedirection"))
+    {
+        // Only enable HSTS when HTTPS redirection is explicitly turned on.
+        app.UseHsts();
+    }
 }
 
-app.UseHttpsRedirection();
+if (builder.Configuration.GetValue<bool>("EnableHttpsRedirection"))
+{
+    app.UseHttpsRedirection();
+}
 app.UseStaticFiles();
 app.UseHttpMetrics();
 

--- a/itu-minitwit/src/MiniTwit.Web/appsettings.json
+++ b/itu-minitwit/src/MiniTwit.Web/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "EnableHttpsRedirection": false,
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",


### PR DESCRIPTION
- Added a one-time Ansible task to cleanly uninstall bare-metal Nginx and Certbot to free ports 80/443.
- Attached the Nginx proxy and ACME companion containers to minitwit_network to enable backend routing.
- Integrated Semgrep SAST into the early CI pipeline to scan C# code for security vulnerabilities.
- Added Trivy to block CI deployments if HIGH/CRITICAL vulnerabilities are found in any Docker images.
- Verified and documented the use of OWASP-compliant, secure, and non-root Docker images forceless non-root Docker base images.
