### PR TITLE
Updated an old Build package due to high severity vulnerability.

### DIFF
--- a/itu-minitwit/src/MiniTwit.Web/MiniTwit.Web.csproj
+++ b/itu-minitwit/src/MiniTwit.Web/MiniTwit.Web.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Build" Version="17.14.28" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
       <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />


### PR DESCRIPTION
Updated an old Build package that according to Trivvy had a high severity .NET Denial of Service https://avd.aquasec.com/nvd/cve-2025-55247  vulnerability.